### PR TITLE
Several updates to the desc-pyspark kernel

### DIFF
--- a/jupyter-kernels/desc-pyspark/desc-pyspark.sh
+++ b/jupyter-kernels/desc-pyspark/desc-pyspark.sh
@@ -7,9 +7,11 @@ fi
 LOGDIR=${SCRATCH}/spark/event_logs
 mkdir -p ${LOGDIR}
 
+# Spark defaults to /tmp, overridden using the SPARK_LOCAL_DIRS environment variable
 # The directory `/global/cscratch1/sd/<user>/tmpfiles` will be created if it
 # does not exist to store temporary files used by Spark.
-mkdir -p ${SCRATCH}/tmpfiles
+mkdir -p ${SCRATCH}/sparktmp
+export SPARK_LOCAL_DIRS="${SCRATCH}/sparktmp"
 
 # Path to LSST miniconda installation at NERSC
 LSSTCONDA="/global/common/software/lsst/common/miniconda"

--- a/jupyter-kernels/desc-pyspark/desc-pyspark.sh
+++ b/jupyter-kernels/desc-pyspark/desc-pyspark.sh
@@ -21,7 +21,7 @@ SPARKPATH="/global/homes/p/peloton/myspark/spark-2.3.2-bin-hadoop2.7"
 
 # Here is the environment needed for Spark to run at NERSC.
 export SPARK_HOME="${SPARKPATH}"
-export PYSPARK_SUBMIT_ARGS="--master local[4]   --driver-memory 32g --executor-memory 32g   --packages com.github.astrolabsoftware:spark-fits_2.11:0.7.1 --conf spark.eventLog.enabled=true --conf spark.eventLog.dir=file://${SCRATCH}/spark/event_logs --conf spark.history.fs.logDirectory=file://${SCRATCH}/spark/event_logs pyspark-shell"
+export PYSPARK_SUBMIT_ARGS="--master local[4] --driver-memory 8g --executor-memory 8g --packages com.github.astrolabsoftware:spark-fits_2.11:0.7.1 --conf spark.eventLog.enabled=true --conf spark.eventLog.dir=file://${SCRATCH}/spark/event_logs --conf spark.history.fs.logDirectory=file://${SCRATCH}/spark/event_logs pyspark-shell"
 export PYTHONSTARTUP="${SPARKPATH}/python/pyspark/shell.py"
 
 # Make sure the version of py4j is correct.

--- a/jupyter-kernels/desc-pyspark/desc-pyspark.sh
+++ b/jupyter-kernels/desc-pyspark/desc-pyspark.sh
@@ -21,7 +21,7 @@ SPARKPATH="/global/homes/p/peloton/myspark/spark-2.3.2-bin-hadoop2.7"
 
 # Here is the environment needed for Spark to run at NERSC.
 export SPARK_HOME="${SPARKPATH}"
-export PYSPARK_SUBMIT_ARGS="--master local[4] --driver-memory 8g --executor-memory 8g --packages com.github.astrolabsoftware:spark-fits_2.11:0.7.1 --conf spark.eventLog.enabled=true --conf spark.eventLog.dir=file://${SCRATCH}/spark/event_logs --conf spark.history.fs.logDirectory=file://${SCRATCH}/spark/event_logs pyspark-shell"
+export PYSPARK_SUBMIT_ARGS="--master local[4] --driver-memory 8g --executor-memory 8g --packages com.github.astrolabsoftware:spark-fits_2.11:0.7.2 --conf spark.eventLog.enabled=true --conf spark.eventLog.dir=file://${SCRATCH}/spark/event_logs --conf spark.history.fs.logDirectory=file://${SCRATCH}/spark/event_logs pyspark-shell"
 export PYTHONSTARTUP="${SPARKPATH}/python/pyspark/shell.py"
 
 # Make sure the version of py4j is correct.

--- a/jupyter-kernels/desc-pyspark/desc-pyspark.sh
+++ b/jupyter-kernels/desc-pyspark/desc-pyspark.sh
@@ -19,7 +19,7 @@ LSSTCONDA="/global/common/software/lsst/common/miniconda"
 # Since the default NERSC Apache Spark runs inside of Shifter, we use
 # a custom local version of it. This is maintained by me (Julien Peloton)
 # at NERSC. If you encounter problems, let me know (peloton at lal.in2p3.fr)!
-SPARKPATH="/global/homes/p/peloton/myspark/spark-2.3.2-bin-hadoop2.7"
+SPARKPATH="/global/homes/p/peloton/myspark/spark-2.4.0-bin-hadoop2.7"
 
 # Here is the environment needed for Spark to run at NERSC.
 export SPARK_HOME="${SPARKPATH}"


### PR DESCRIPTION
### What this PR brings?

This PR brings several updates to the desc-pyspark kernel:

- [critical]: Limit the memory available for Apache Spark workers. The previous threshold was rather high, causing Spark processes to consume disproportionate system resources.
- [small]: For storing temporary files, override `/tmp`by `$SCRATCH/sparktmp` by setting explicitly `SPARK_LOCAL_DIRS`.
- [minor]: Bump Spark version (2.3.2 -> 2.4.0), and spark-fits version (0.7.1 -> 0.7.2).

### How this has been tested?

Manually - works fine.