### PR TITLE
Adding current working directory to PYTHONPATH

### DIFF
--- a/jupyter-kernels/setup/stack.sh
+++ b/jupyter-kernels/setup/stack.sh
@@ -13,6 +13,8 @@ if [ -n "$DESCPYTHONPATH" ]; then
     echo "Including user python path: $DESCPYTHONPATH"
 fi
 
+export PYTHONPATH="'.':$PYTHONPATH"
+
 if [ $# -gt 0 ] ; then
     exec python -m ipykernel $@
 fi


### PR DESCRIPTION
Supports locally defined python modules such as those in DC2-analysis tutorials.  This works with the desc-stack-dev kernel.