### PR TITLE
Move from obs_lsstCam to obs_lsst

### DIFF
--- a/jupyter-kernels/setup/stack.sh
+++ b/jupyter-kernels/setup/stack.sh
@@ -2,7 +2,7 @@
 
 source /opt/lsst/software/stack/loadLSST.bash ""
 setup lsst_distrib
-setup -r /opt/lsst/software/stack/obs_lsstCam
+setup -r /opt/lsst/software/stack/obs_lsst
 setup lsst_sims
 export OMP_NUM_THREADS=1
 


### PR DESCRIPTION
Complete migration to obs_lsst from obs_lsstCam

The docker images have now moved to use obs_lsst rather than obs_lsstCam since Run1.2p_v4 is the first 1.2p reprocessing to use obs_lsst rather than obs_lsstCam