### PR TITLE
Change jupyter.log to .jupyter.log

### DIFF
--- a/scripts/jupyter-debug.sh
+++ b/scripts/jupyter-debug.sh
@@ -77,5 +77,5 @@ echo
 echo '========================'
 echo 'Content of ~/jupyter.log'
 echo '========================'
-tail -n 100 ~/jupyter.log
+tail -n 100 ~/.jupyter.log
 )

--- a/scripts/jupyter-debug.sh
+++ b/scripts/jupyter-debug.sh
@@ -75,7 +75,7 @@ cat ~/.bash_profile.ext
 
 echo 
 echo '========================'
-echo 'Content of ~/jupyter.log'
+echo 'Content of ~/.jupyter.log'
 echo '========================'
 tail -n 100 ~/.jupyter.log
 )


### PR DESCRIPTION
According to NERSC Jupyter Users email, logging Now Goes to ~/.jupyter.log not ~/jupyter.log.

This PR updates the debugging script accordingly.