### PR TITLE
remove PYTHONSTARTUP and use stack conda env

### DIFF
--- a/jupyter-kernels/setup/setup_current_python.sh
+++ b/jupyter-kernels/setup/setup_current_python.sh
@@ -17,9 +17,9 @@ done
 export LSST_INST_DIR=/global/common/software/lsst/common/miniconda
 export LSST_PYTHON_VER=current
 
-module load pe_archive
 module unload python
 module swap PrgEnv-intel PrgEnv-gnu
+module load pe_archive
 module swap gcc gcc/6.3.0
 module rm craype-network-aries
 module rm cray-libsci
@@ -28,6 +28,7 @@ export CC=gcc
 
 unset PYTHONHOME
 unset PYTHONPATH
+unset PYTHONSTARTUP
 export PYTHONNOUSERSITE=' '
 
 if [ -n "$DESCPYTHONPATH" ]; then
@@ -36,4 +37,5 @@ if [ -n "$DESCPYTHONPATH" ]; then
 fi 
 
 export PATH=$LSST_INST_DIR/$LSST_PYTHON_VER/bin:$PATH
+source activate stack
 echo Now using $LSST_INST_DIR/$LSST_PYTHON_VER

--- a/jupyter-kernels/setup/stack.sh
+++ b/jupyter-kernels/setup/stack.sh
@@ -6,6 +6,8 @@ setup -r /opt/lsst/software/stack/obs_lsst
 setup lsst_sims
 export OMP_NUM_THREADS=1
 
+unset PYTHONSTARTUP
+
 export PYTHONNOUSERSITE=' '
 
 if [ -n "$DESCPYTHONPATH" ]; then


### PR DESCRIPTION
PYTHONSTARTUP is set by default on Cori, but this is not recommended for those who use their own Anaconda environments as we do.  In particular, the path `/etc/` does not exist in our shifter images, and a warning is generated due to the missing PYTHONSTARTUP.