### PR TITLE
reinstate PYTHONSTARTUP in setup_current_python.sh which is used by pyspark

### DIFF
--- a/jupyter-kernels/setup/setup_current_python.sh
+++ b/jupyter-kernels/setup/setup_current_python.sh
@@ -28,7 +28,6 @@ export CC=gcc
 
 unset PYTHONHOME
 unset PYTHONPATH
-unset PYTHONSTARTUP
 export PYTHONNOUSERSITE=' '
 
 if [ -n "$DESCPYTHONPATH" ]; then


### PR DESCRIPTION
Leaving desc-stack without PYTHONSTARTUP, but reinstating PYTHONSTARTUP in setup_current_python.sh which is used by pyspark.