### PR TITLE
update nersc jupyter URL

### DIFF
--- a/jupyter-kernels/setup/user_setup.sh
+++ b/jupyter-kernels/setup/user_setup.sh
@@ -22,5 +22,4 @@ jupyter kernelspec install $INST_DIR/kernels/desc-stack-old --user
 jupyter kernelspec install $INST_DIR/kernels/desc-pyspark --user
 jupyter kernelspec install $INST_DIR/kernels/desc-sims --user
 echo "Your JupyterLab URL is: "
-echo https://jupyter.nersc.gov/user/$USER/lab/tree/$HOME
-
+echo "https://jupyter.nersc.gov/user/$USER/cori-shared-node-cpu/lab/tree/$HOME"


### PR DESCRIPTION
The original nersc jupyter URL no longer works. 