### PR TITLE
move back to gcc 6.3.0 now that NERSC has reinstalled it

### DIFF
--- a/jupyter-kernels/setup/setup_current_python.sh
+++ b/jupyter-kernels/setup/setup_current_python.sh
@@ -19,7 +19,7 @@ export LSST_PYTHON_VER=current
 
 module unload python
 module swap PrgEnv-intel PrgEnv-gnu
-module swap gcc gcc/7.3.0
+module swap gcc gcc/6.3.0
 module rm craype-network-aries
 module rm cray-libsci
 module unload craype


### PR DESCRIPTION
NERSC kindly reinstalled gcc 6.3.0 and for consistency with installed python packages,including camb, as mentioned here https://github.com/LSSTDESC/descqa/issues/181, we are moving back to gcc 6.3.0
